### PR TITLE
Update deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,20 @@
 language: python
-sudo: false
+dist: jammy
 cache: pip
-env:
-  global:
-    - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
-    - SEGFAULT_SIGNALS=all
-matrix:
+jobs:
   include:
-    - python: '3.6'
-      env:
-        - TOXENV=py36,report,check,docs
     - python: '3.7'
-      dist: xenial
-      sudo: required
       env:
         - TOXENV=py37,report
     - python: '3.8'
-      dist: xenial
-      sudo: required
       env:
         - TOXENV=py38,report
+    - python: '3.9.0'
+      env:
+        - TOXENV=py39,report
+    - python: '3.10.5'
+      env:
+        - TOXENV=py310,report,check,docs
 addons:
   apt:
     packages:
@@ -35,7 +30,6 @@ before_install:
 install:
   - pip install tox
   - virtualenv --version
-  - easy_install --version
   - pip --version
   - tox --version
 script:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,22 +1,22 @@
 Changelog
 =========
 
-1.0a1 (2019-2-1)
------------------
+1.0b3 (2019-10-21)
+------------------
 
-* Initial release.
-
-1.0b1 (2019-2-9)
-----------------
-
-* Added documentation.
+* Upgrade to stable version of Grimp.
 
 1.0b2 (2019-4-24)
 -----------------
 
 * Upgraded Grimp.
 
-1.0b3 (2019-10-21)
-------------------
+1.0b1 (2019-2-9)
+----------------
 
-* Upgrade to stable version of Grimp.
+* Added documentation.
+
+1.0a1 (2019-2-1)
+-----------------
+
+* Initial release.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+latest
+------
+
+* Remove upper bounds on dependencies.
+* Drop support for Python 3.6.
+* Add support for Python 3.9 and 3.10.
+
 1.0b3 (2019-10-21)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 ignore = E731
 max-line-length = 100
 exclude = */migrations/*, tests/assets/*
+
+[mypy-pytest]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -46,16 +46,17 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Utilities',
     ],
     install_requires=[
-        'click>=6,<8',
-        'graphviz>=0.10,<1',
-        'grimp>=1,<2',
+        'click>=6',
+        'graphviz>=0.10',
+        'grimp>=1',
     ],
     entry_points={
         'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,15 @@ envlist =
     clean,
     check,
     docs,
-    {py36,py37,py38}-click{6,7},
+    {py37,py38,py39,py310},
     report
 
 [testenv]
 basepython =
-    py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
+    py39: {env:TOXPYTHON:python3.9}
+    py310: {env:TOXPYTHON:python3.10}
     {clean,check,docs,report}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
@@ -19,20 +20,19 @@ passenv =
     *
 usedevelop = false
 deps =
-    pytest==3.10.0
+    pytest==7.1.3
     pytest-travis-fold==1.3.0
-    pytest-cov==2.6.0
-
-    click6: click==6
-    click7: click==7
+    pytest-cov==4.0.0
+    click==8.1.3
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
     impulse drawgraph grimp
 
 [testenv:check]
 deps =
-    flake8
-    mypy
+    click==8.1.3
+    flake8==5.0.4
+    mypy==0.982
 skip_install = true
 commands =
     flake8 src tests setup.py
@@ -46,7 +46,7 @@ commands =
     sphinx-build -b linkcheck docs dist/docs
 
 [testenv:report]
-deps = coverage==4.5.1
+deps = coverage==6.5.0
 skip_install = true
 commands =
     coverage report


### PR DESCRIPTION
Most significantly, drops the upper bounds on dependencies.

Also drops official support for Python 3.6 and adds support for 3.9 and 3.10.