### PR TITLE
Support to pass graphviz output format

### DIFF
--- a/src/impulse/application/use_cases.py
+++ b/src/impulse/application/use_cases.py
@@ -7,7 +7,7 @@ from graphviz import Digraph  # type: ignore
 import grimp  # type: ignore
 
 
-def draw_graph(module_name: str) -> None:
+def draw_graph(module_name: str, file_format="png") -> None:
     """
     Create a file showing a graph of the supplied package.
     Args:
@@ -21,7 +21,7 @@ def draw_graph(module_name: str) -> None:
     module_children = graph.find_children(module.name)
 
     dot = Digraph(
-        format='png',
+        format=file_format,
         node_attr={'fontname': 'helvetica'}
     )
     dot.attr(

--- a/src/impulse/cli.py
+++ b/src/impulse/cli.py
@@ -9,7 +9,9 @@ def main():
 
 @main.command()
 @click.argument('module_name', type=str)
-def drawgraph(module_name):
+@click.option('--format', type=str, default='png')
+def drawgraph(module_name, format):
     use_cases.draw_graph(
         module_name=module_name,
+        file_format=format,
     )


### PR DESCRIPTION
PDF is much crisper

Tested locally with:
```shell
impulse drawgraph --format pdf [my_package]
```

png:
<img width="600" src="https://github.com/seddonym/impulse/assets/9756388/a3b32fdc-57a5-438d-abf6-5c36430c80b6">

pdf:
<img width="600" src="https://github.com/seddonym/impulse/assets/9756388/6b322535-48e0-4730-b60d-b2d77e287d94">
