### PR TITLE
Support namespace packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ latest
 ------
 
 * Add --show-cycle-breakers flag.
+* Support namespace packages.
 
 2.0 (2025-10-20)
 ----------------

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ install-precommit:
 test:
     @uv run pytest
     @uv run impulse drawgraph grimp
+    @uv run --with=google-cloud-audit-log impulse drawgraph google.cloud.audit
     @uv run impulse drawgraph grimp --show-import-totals
     @uv run --with=django impulse drawgraph django.db --show-cycle-breakers
 

--- a/src/impulse/adapters.py
+++ b/src/impulse/adapters.py
@@ -3,6 +3,7 @@ import webbrowser
 from impulse import ports
 from textwrap import dedent
 from impulse import dotfile
+import importlib
 
 
 class BrowserGraphViewer(ports.GraphViewer):
@@ -169,3 +170,21 @@ class BrowserGraphViewer(ports.GraphViewer):
 
         # Open in browser
         webbrowser.open(f"file://{html_path}")
+
+
+def get_top_level_package(module_name: str) -> str:
+    """
+    Returns the top-level package name from the given module name.
+
+    This will usually be the first part of the dotted module name (before the first dot), but for namespace packages
+    it will be the 'portion' name.
+    """
+
+    # Successively work through the module components until we encounter one with a corresponding file.
+    components = module_name.split(".")
+    for level in range(len(components)):
+        candidate_name = ".".join(components[: level + 1])
+        candidate = importlib.import_module(candidate_name)
+        if candidate.__file__:
+            return candidate_name
+    raise ImportError(f"Can't import module '{module_name}'. Is it on the Python path?")

--- a/src/impulse/application/use_cases.py
+++ b/src/impulse/application/use_cases.py
@@ -12,6 +12,7 @@ def draw_graph(
     show_cycle_breakers: bool,
     sys_path: list[str],
     current_directory: str,
+    get_top_level_package: Callable[[str], str],
     build_graph: Callable[[str], grimp.ImportGraph],
     viewer: ports.GraphViewer,
 ) -> None:
@@ -23,6 +24,8 @@ def draw_graph(
         show_cycle_breakers: marks a set of dependencies that, if removed, would make the graph acyclic.
         sys_path: the sys.path list (or a test double).
         current_directory: the current working directory.
+        get_top_level_package: the function to retrieve the top level package name. This will usually be the first part
+            of the dotted module name (before the first dot), but for namespace packages it should be the 'portion' name.
         build_graph: the function which builds the graph of the supplied package
             (pass grimp.build_graph or a test double).
         viewer: GraphViewer for generating the graph image and opening it.
@@ -30,8 +33,8 @@ def draw_graph(
     # Add current directory to the path, as this doesn't happen automatically.
     sys_path.insert(0, current_directory)
 
-    module = grimp.Module(module_name)
-    grimp_graph = build_graph(module.package_name)
+    top_level_package = get_top_level_package(module_name)
+    grimp_graph = build_graph(top_level_package)
 
     dot = _build_dot(grimp_graph, module_name, show_import_totals, show_cycle_breakers)
 

--- a/src/impulse/cli.py
+++ b/src/impulse/cli.py
@@ -35,6 +35,7 @@ def drawgraph(module_name: str, show_import_totals: bool, show_cycle_breakers: b
         show_cycle_breakers=show_cycle_breakers,
         sys_path=sys.path,
         current_directory=os.getcwd(),
+        get_top_level_package=adapters.get_top_level_package,
         build_graph=grimp.build_graph,
         viewer=adapters.BrowserGraphViewer(),
     )


### PR DESCRIPTION
Prior to this, attempting to drawgraph on namespace packages would error.

```
uv run --with=google-cloud-audit-log impulse drawgraph google.cloud.audit
...
grimp.exceptions.NamespacePackageEncountered: Package 'google' is a namespace package (see PEP 420). Try specifying the portion name instead. If you are not intentionally using namespace packages, adding an __init__.py file should fix the problem.
```

This fixes it.